### PR TITLE
Use Bootstrap dropdown background color

### DIFF
--- a/src/select2-bootstrap4.scss
+++ b/src/select2-bootstrap4.scss
@@ -15,6 +15,7 @@ $s2bs-caret-padding: $custom-select-indicator-padding !default;
 $s2bs-caret-width-base: 0.25rem !default;
 $s2bs-caret-width-large: 0.3125rem !default;
 $s2bs-cursor-disabled: not-allowed !default;
+$s2bs-dropdown-bg: $dropdown-bg !default;
 $s2bs-dropdown-header-color: $dropdown-header-color !default;
 $s2bs-dropdown-link-active-bg: $dropdown-link-active-bg !default;
 $s2bs-dropdown-link-active-color: $dropdown-link-active-color !default;
@@ -291,6 +292,8 @@ $s2bs-form-control-transition: border-color ease-in-out .15s, box-shadow ease-in
     border-width: $s2bs-input-border-width;
     overflow-x: hidden;
     margin-top: -1px;
+    
+    background-color: $dropdown-bg;
 
     &--above {
       @include box-shadow($s2bs-dropdown-box-shadow-above);


### PR DESCRIPTION
Previously the dropdown did not have an explicit background color set, so it defaulted to the `body` background color from Select2, which is `#fff` . If you were using a dark theme such as [bootswatch/darkly](https://bootswatch.com/darkly/) , it would not match the theme backgrounds. 

Example:

<img width="849" alt="Screen Shot 2019-11-26 at 10 16 17 AM" src="https://user-images.githubusercontent.com/162151/69618864-e4250380-103a-11ea-8d92-354ec6aa73ed.png">

This change brings the dropdown colors in line with Bootstrap's dropdown theme:

<img width="877" alt="Screen Shot 2019-11-26 at 10 53 33 AM" src="https://user-images.githubusercontent.com/162151/69618929-061e8600-103b-11ea-9a0f-525331f06800.png">

Not sure if I should update what's in `dist/` in this PR. Also I couldn't get `npm test` to run. Any advice? Thanks!